### PR TITLE
New code to fill in some masked cloud areas; new Otsu thresholds	

### DIFF
--- a/EE-scripts/annualMiningArea.js
+++ b/EE-scripts/annualMiningArea.js
@@ -214,7 +214,7 @@ var mining = ee.ImageCollection(nullCleaning3.map(function(image){
   var area = ee.Image.pixelArea().multiply(mtrMasked)
     .divide(ee.Image.constant(year)).rename('area');
   
-  return image.addBands(mtrMasked).addBands(area).set({"year": year});
+  return image.addBands(mtrMasked).addBands(area);
 }));
 
 /*------------ SUMMARIZE MINING AREA PER FEATURE PER YEAR --------------------*/


### PR DESCRIPTION
There's new code here to fill in nulled out cloud areas with mining information if the immediately previous and future years had mining too. I also updated the Otsu thresholds with the new imagery set.